### PR TITLE
Codex/configure access restrictions for guests

### DIFF
--- a/assets/App.vue
+++ b/assets/App.vue
@@ -269,8 +269,15 @@ export default {
       this.folders = [];
       this.loading = true;
       fetch(`/api/children/${this.cwd}`)
-        .then((res) => res.json())
+        .then((res) => {
+          if (!res.ok) {
+            this.loading = false;
+            return null;
+          }
+          return res.json();
+        })
         .then((files) => {
+          if (!files) return;
           this.files = files.value;
           if (this.order) {
             this.files.sort((a, b) => {

--- a/functions/api/children/[[path]].ts
+++ b/functions/api/children/[[path]].ts
@@ -8,10 +8,14 @@ export async function onRequestGet(context) {
     if (!bucket || prefix.startsWith("_$flaredrive$/")) return notFound();
     const allowList = get_allow_list(context);
     if (!allowList) {
-      return new Response("没有读取权限", { status: 401 });
+      const headers = new Headers();
+      headers.set("WWW-Authenticate", 'Basic realm="需要登录"');
+      return new Response("没有读取权限", { status: 401, headers });
     }
     if (prefix && !can_access_path(context, prefix)) {
-      return new Response("没有读取权限", { status: 401 });
+      const headers = new Headers();
+      headers.set("WWW-Authenticate", 'Basic realm="需要登录"');
+      return new Response("没有读取权限", { status: 401, headers });
     }
 
     const objList = await bucket.list({

--- a/functions/api/children/[[path]].ts
+++ b/functions/api/children/[[path]].ts
@@ -40,6 +40,9 @@ export async function onRequestGet(context) {
       folders = folders.filter((folder) =>
         allowList.some((allow) => folder.startsWith(allow))
       );
+      for (const allow of allowList) {
+        if (!folders.includes(allow)) folders.push(allow);
+      }
     }
 
     return new Response(JSON.stringify({ value: objKeys, folders }), {

--- a/functions/api/children/[[path]].ts
+++ b/functions/api/children/[[path]].ts
@@ -1,17 +1,25 @@
 import { notFound, parseBucketPath } from "@/utils/bucket";
+import { can_access_path, get_allow_list } from "@/utils/auth";
 
 export async function onRequestGet(context) {
   try {
     const [bucket, path] = parseBucketPath(context);
     const prefix = path && `${path}/`;
     if (!bucket || prefix.startsWith("_$flaredrive$/")) return notFound();
+    const allowList = get_allow_list(context);
+    if (!allowList) {
+      return new Response("没有读取权限", { status: 401 });
+    }
+    if (prefix && !can_access_path(context, prefix)) {
+      return new Response("没有读取权限", { status: 401 });
+    }
 
     const objList = await bucket.list({
       prefix,
       delimiter: "/",
       include: ["httpMetadata", "customMetadata"],
     });
-    const objKeys = objList.objects
+    let objKeys = objList.objects
       .filter((obj) => !obj.key.endsWith("/_$folder$"))
       .map((obj) => {
         const { key, size, uploaded, httpMetadata, customMetadata } = obj;
@@ -21,6 +29,14 @@ export async function onRequestGet(context) {
     let folders = objList.delimitedPrefixes;
     if (!path)
       folders = folders.filter((folder) => folder !== "_$flaredrive$/");
+    if (!allowList.includes("*") && !path) {
+      objKeys = objKeys.filter((obj) =>
+        allowList.some((allow) => obj.key.startsWith(allow))
+      );
+      folders = folders.filter((folder) =>
+        allowList.some((allow) => folder.startsWith(allow))
+      );
+    }
 
     return new Response(JSON.stringify({ value: objKeys, folders }), {
       headers: { "Content-Type": "application/json" },

--- a/functions/raw/[[path]].ts
+++ b/functions/raw/[[path]].ts
@@ -5,7 +5,9 @@ export async function onRequestGet(context) {
   const [bucket, path] = parseBucketPath(context);
   if (!bucket) return notFound();
   if (!can_access_path(context, path || "")) {
-    return new Response("没有读取权限", { status: 401 });
+    const headers = new Headers();
+    headers.set("WWW-Authenticate", 'Basic realm="需要登录"');
+    return new Response("没有读取权限", { status: 401, headers });
   }
   const url = context.env["PUBURL"] + "/" + context.request.url.split("/raw/")[1]
 

--- a/functions/raw/[[path]].ts
+++ b/functions/raw/[[path]].ts
@@ -1,8 +1,12 @@
 import { notFound, parseBucketPath } from "@/utils/bucket";
+import { can_access_path } from "@/utils/auth";
 
 export async function onRequestGet(context) {
   const [bucket, path] = parseBucketPath(context);
   if (!bucket) return notFound();
+  if (!can_access_path(context, path || "")) {
+    return new Response("没有读取权限", { status: 401 });
+  }
   const url = context.env["PUBURL"] + "/" + context.request.url.split("/raw/")[1]
 
   var response =await fetch(new Request(url, {


### PR DESCRIPTION
00

## Summary by Sourcery

Restrict guest and authenticated access to objects and directories based on configured allow-lists, and apply these restrictions consistently across raw and children listing endpoints.

New Features:
- Introduce shared helpers to parse allow-lists and evaluate path access, including a dedicated thumbnail exemption and access-check function.
- Expose an endpoint helper to retrieve the effective allow-list for the current request and use it to filter visible files and folders in directory listings.

Bug Fixes:
- Ensure unauthenticated or unauthorized requests to children and raw endpoints are rejected with a 401 response and WWW-Authenticate header instead of proceeding.
- Prevent access to or listing of paths not explicitly allowed for guest or authenticated users, while still permitting thumbnail access.

Enhancements:
- Refactor authentication logic into reusable utilities for cleaner, more consistent access control across endpoints.
- Update the frontend to gracefully handle non-OK responses from the children API without breaking the UI.